### PR TITLE
Bump Django to version 2.2.28

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ coreapi==2.3.3
 coreschema==0.0.4
 debtcollector==1.20.0
 defusedxml==0.6.0
-Django==2.2.24
+Django==2.2.28
 django-debug-toolbar==1.11.1
 django-extensions==2.1.4
 django-filter==2.0.0


### PR DESCRIPTION
Bump Django because of CVE-2022-28346.
https://docs.djangoproject.com/en/4.0/releases/2.2.28/