### PR TITLE
Bump dependencies for Python 3.10 compat

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,14 +17,14 @@ djangorestframework-xml==1.4.0
 drf-amsterdam==0.1.8
 drf-extensions==0.4.0
 elasticsearch==6.3.1
-elasticsearch-dsl==6.2.1
+elasticsearch-dsl==6.4.0
 factory-boy==2.11.1
 Faker==1.0.1
 graypy==0.3.1
 idna==2.8
 ipaddress==1.0.22
 iso8601==0.1.12
-itypes==1.1.0
+itypes==1.2.0
 Jinja2==2.11.3
 keystoneauth1==3.11.2
 MarkupSafe==2.1.1


### PR DESCRIPTION
manage.py run_import no longer crashes on startup because collections.Mapping disappeared in Python 3.10.

For AB#79138.